### PR TITLE
Rename call(_ :) to callAsFunction(_ :)

### DIFF
--- a/S4TF_Tutorial_2.ipynb
+++ b/S4TF_Tutorial_2.ipynb
@@ -225,7 +225,7 @@
         "\n",
         "The [Swift for TensorFlow Deep Learning Library](https://github.com/tensorflow/swift-apis) defines primitive layers and conventions for wiring them together, which makes it easy to build models and experiment.\n",
         "\n",
-        "A model is a `struct` that conforms to [`Layer`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer), which means that it defines a [`call(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer#call_:) method that maps input `Tensor`s to output `Tensor`s. The `call(_:)` method often simply sequences the input through sublayers. Let's define an `CelsiusToFahrenheit` that sequences the input through a single [`Dense`](https://www.tensorflow.org/swift/api_docs/Structs/Dense) layer.\n",
+        "A model is a `struct` that conforms to [`Layer`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer), which means that it defines a [`callAsFunction(_:)`](https://www.tensorflow.org/swift/api_docs/Protocols/Layer) method that maps input `Tensor`s to output `Tensor`s. The `callAsFunction(_:)` method often simply sequences the input through sublayers. Let's define an `CelsiusToFahrenheit` that sequences the input through a single [`Dense`](https://www.tensorflow.org/swift/api_docs/Structs/Dense) layer.\n",
         "\n",
         "*   `inputSize: 1` — This specifies that the input to this layer is a single value. Since this is the first (and only) layer, that input shape is the input shape of the entire model. The single value is a Tensor matrix of floating point numbers, representing degrees Celsius.\n",
         "\n",


### PR DESCRIPTION
Great notebooks @Ayush517. Just thought maybe we could update Layer.call(_ :) to callAsFunction(_ :) in the text portion of the tutorial, since the code is already updated :
 
(as per @rxwei 5 Jun: https://github.com/tensorflow/swift-models/issues/165)

Correct me if I'm wrong and keep up the awesome work!